### PR TITLE
Update version in download badge + typo in doc

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 <!-- for main -->
 
-[![Download](https://img.shields.io/badge/Download-0.15.1-%23007ec6)](https://search.maven.org/artifact/ch.tutteli.kbox/kbox/0.15.1/jar)
+[![Download](https://img.shields.io/badge/Download-0.16.0-%23007ec6)](https://search.maven.org/artifact/ch.tutteli.kbox/kbox/0.16.0/jar)
 [![Apache license](https://img.shields.io/badge/license-Apache%202.0-brightgreen.svg)](http://opensource.org/licenses/Apache2.0)
 [![Build Status Ubuntu](https://github.com/robstoll/kbox/workflows/Ubuntu/badge.svg?event=push)](https://github.com/robstoll/kbox/actions?query=workflow%3AUbuntu+branch%3Amain)
 [![Build Status Windows](https://github.com/robstoll/kbox/workflows/Windows/badge.svg?event=push)](https://github.com/robstoll/kbox/actions?query=workflow%3AWindows+branch%3Amain)

--- a/src/commonMain/kotlin/ch/tutteli/kbox/identity.kt
+++ b/src/commonMain/kotlin/ch/tutteli/kbox/identity.kt
@@ -1,7 +1,7 @@
 package ch.tutteli.kbox
 
 /**
- * An idendity function which inlines if possible.
+ * An identity function which inlines if possible.
  */
 @Suppress("NOTHING_TO_INLINE")
 inline fun <T> identity(t: T): T = t


### PR DESCRIPTION
I noticed that I missed the download badge/link for the latest version in my last PR, and found a quick typo fix in the docs for Identity