### PR TITLE
only apply java-base instead of java to get rid of MPP issues, update tutteli to 5.0.3

### DIFF
--- a/gradle/build-logic/dev/src/main/kotlin/build-logic.java.gradle.kts
+++ b/gradle/build-logic/dev/src/main/kotlin/build-logic.java.gradle.kts
@@ -1,5 +1,5 @@
 plugins {
-    id("java")
+    id("java-base")
     id("build-logic.gradle-conventions")
 }
 
@@ -8,8 +8,10 @@ java {
         // reading JAVA_VERSION from env to enable jdk17 build in CI
         languageVersion.set(JavaLanguageVersion.of(buildParameters.java.version))
     }
-    consistentResolution {
-        useCompileClasspathVersions()
+    project.afterEvaluate {
+        consistentResolution {
+            useCompileClasspathVersions()
+        }
     }
 }
 

--- a/gradle/build-logic/dev/src/main/kotlin/build-logic.junit-jacoco-conventions.gradle.kts
+++ b/gradle/build-logic/dev/src/main/kotlin/build-logic.junit-jacoco-conventions.gradle.kts
@@ -1,9 +1,15 @@
+import org.gradle.api.tasks.testing.logging.TestLogEvent
+
 plugins {
     id("ch.tutteli.gradle.plugins.junitjacoco")
 }
 
-dependencies {
-    // used to run the samples
-    testImplementation("org.junit.jupiter:junit-jupiter-api")
-    testImplementation("org.junit.jupiter:junit-jupiter-params")
+// adjust because we use com.github.vlsi.gradle-extensions which prints tests differently, otherwise we print
+// the failed tests twice.
+tasks.withType<Test>().configureEach {
+    testLogging {
+        // Empty enum throws "Collection is empty", so we use Iterable method
+        setEvents((events - TestLogEvent.FAILED) as Iterable<TestLogEvent>)
+        showStackTraces = false
+    }
 }

--- a/gradle/build-logic/dev/src/main/kotlin/build-logic.kotlin-conventions.gradle.kts
+++ b/gradle/build-logic/dev/src/main/kotlin/build-logic.kotlin-conventions.gradle.kts
@@ -4,6 +4,7 @@ import org.jetbrains.kotlin.gradle.tasks.KotlinCompilationTask
 plugins {
     id("build-logic.gradle-conventions")
 }
+
 tasks.configureEach<KotlinCompilationTask<*>> {
     compilerOptions {
         freeCompilerArgs.add("-opt-in=kotlin.RequiresOptIn")

--- a/gradle/build-logic/dev/src/main/kotlin/build-logic.kotlin-jvm-conventions.gradle.kts
+++ b/gradle/build-logic/dev/src/main/kotlin/build-logic.kotlin-jvm-conventions.gradle.kts
@@ -3,15 +3,14 @@ import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 
 plugins {
     id("build-logic.kotlin-conventions")
-    id("build-logic.junit-jacoco-conventions")
     // this plugin sets inter alia toolchain and source/targetCompatibility
     // but also applies common plugins such as gradle-convention, build-params
     id("build-logic.java")
-    id("ch.tutteli.gradle.plugins.kotlin.module.info")
+    id("build-logic.junit-jacoco-conventions")
 }
 
 tasks.configureEach<KotlinCompile> {
-    compilerOptions{
+    compilerOptions {
         jvmTarget.set(JvmTarget.fromTarget(buildParameters.defaultJdkVersion.toString()))
     }
 }

--- a/gradle/build-logic/dev/src/main/kotlin/build-logic.kotlin-jvm.gradle.kts
+++ b/gradle/build-logic/dev/src/main/kotlin/build-logic.kotlin-jvm.gradle.kts
@@ -1,8 +1,0 @@
-plugins {
-    kotlin("jvm")
-    id("build-logic.kotlin-jvm-conventions")
-}
-
-dependencies {
-    testImplementation("org.jetbrains.kotlin:kotlin-test-junit5")
-}

--- a/gradle/build-logic/dev/src/main/kotlin/build-logic.kotlin-multiplatform-conventions.gradle.kts
+++ b/gradle/build-logic/dev/src/main/kotlin/build-logic.kotlin-multiplatform-conventions.gradle.kts
@@ -1,0 +1,26 @@
+import org.gradle.kotlin.dsl.kotlin
+
+plugins {
+    kotlin("multiplatform")
+    id("build-logic.gradle-conventions")
+}
+
+kotlin {
+    sourceSets {
+        // necessary due to https://youtrack.jetbrains.com/issue/KT-65352/KMP-Gradle-impossible-to-set-language-apiVersion-for-common-to-1.4
+        all {
+            languageSettings {
+                languageVersion = buildParameters.kotlin.version
+                apiVersion = buildParameters.kotlin.version
+            }
+        }
+    }
+}
+
+// this is necessary due to some crazy kotlin plugin voodoo. If we define this in the rootProject itself,
+// then it does not work.
+rootProject.plugins.withType<org.jetbrains.kotlin.gradle.targets.js.yarn.YarnPlugin> {
+    rootProject.configure<org.jetbrains.kotlin.gradle.targets.js.yarn.YarnRootExtension> {
+        lockFileDirectory = rootProject.projectDir.resolve("gradle")
+    }
+}

--- a/gradle/build-logic/dev/src/main/kotlin/build-logic.kotlin-multiplatform.gradle.kts
+++ b/gradle/build-logic/dev/src/main/kotlin/build-logic.kotlin-multiplatform.gradle.kts
@@ -1,8 +1,7 @@
 plugins {
-    kotlin("multiplatform")
+    id("build-logic.kotlin-multiplatform-conventions")
     id("build-logic.kotlin-jvm-conventions")
 }
-
 
 kotlin {
     jvm {
@@ -18,21 +17,5 @@ kotlin {
                 implementation(kotlin("test"))
             }
         }
-
-        // necessary due to https://youtrack.jetbrains.com/issue/KT-65352/KMP-Gradle-impossible-to-set-language-apiVersion-for-common-to-1.4
-        all {
-            languageSettings {
-                languageVersion = buildParameters.kotlin.version
-                apiVersion = buildParameters.kotlin.version
-            }
-        }
-    }
-}
-
-// this is necessary due to some crazy kotlin plugin voodoo. If we define this in the rootProject itself,
-// then it does not work.
-rootProject.plugins.withType<org.jetbrains.kotlin.gradle.targets.js.yarn.YarnPlugin> {
-    rootProject.configure<org.jetbrains.kotlin.gradle.targets.js.yarn.YarnRootExtension> {
-        lockFileDirectory = rootProject.projectDir.resolve("gradle")
     }
 }

--- a/gradle/build-logic/publishing/src/main/kotlin/build-logic.published-kotlin-multiplatform.gradle.kts
+++ b/gradle/build-logic/publishing/src/main/kotlin/build-logic.published-kotlin-multiplatform.gradle.kts
@@ -1,7 +1,6 @@
-import ch.tutteli.gradle.plugins.publish.PublishPluginExtension
-
 plugins {
     id("build-logic.kotlin-multiplatform")
     id("build-logic.dokka")
     id("ch.tutteli.gradle.plugins.publish")
+    id("ch.tutteli.gradle.plugins.kotlin.module.info")
 }

--- a/gradle/buildLibs.versions.toml
+++ b/gradle/buildLibs.versions.toml
@@ -3,7 +3,7 @@ dokka = "1.9.20"
 jacocoTool = "0.8.9"
 kotlin = "2.0.21"
 task-tree = "4.0.0"
-tutteli = "5.0.1"
+tutteli = "5.0.3"
 vlsi = "1.90"
 
 [libraries]


### PR DESCRIPTION
moreover:
- solve the double gradle test error message printing caused by vlsi-gradle-extension