### PR TITLE
rename toVarArg to toVararg in order to be in line with varargToList

### DIFF
--- a/gradle/code-generation/src/main/kotlin/code-generation.generate.gradle.kts
+++ b/gradle/code-generation/src/main/kotlin/code-generation.generate.gradle.kts
@@ -75,7 +75,7 @@ val generate: TaskProvider<Task> = tasks.register("generate") {
         val tupleFlatten = createStringBuilder(packageName)
             .append("import kotlin.jvm.JvmName")
 
-        val toVarArg = createStringBuilder(packageName)
+        val toVararg = createStringBuilder(packageName)
             .append("import kotlin.jvm.JvmName")
 
         (2..numOfArgs).forEach { upperNumber ->
@@ -327,7 +327,7 @@ val generate: TaskProvider<Task> = tasks.register("generate") {
             }
         }
 
-        toVarArg.append(
+        toVararg.append(
             """
             |/**
             | * Splits this [Array] into the first element and the rest as `Array<out T>`.
@@ -336,7 +336,7 @@ val generate: TaskProvider<Task> = tasks.register("generate") {
             | *
             | * @since 3.1.0
             | */
-            |inline fun <reified T> Array<out T>.toVarArg(): Pair<T, Array<out T>> =
+            |inline fun <reified T> Array<out T>.toVararg(): Pair<T, Array<out T>> =
             |   first() to drop(1).toList().toTypedArray()
             |
             """.trimMargin()
@@ -345,7 +345,7 @@ val generate: TaskProvider<Task> = tasks.register("generate") {
 
         primitiveTypes.forEach { (type, arrayType) ->
             listOf("Iterable", "Array").forEach { receiver ->
-                toVarArg.append(
+                toVararg.append(
                     """
                     |/**
                     | * Splits this [$receiver] into the first element and the rest as [$arrayType].
@@ -354,14 +354,14 @@ val generate: TaskProvider<Task> = tasks.register("generate") {
                     | *
                     | * @since 3.1.0
                     | */
-                    |@JvmName("toVarArg$type")
-                    |fun $receiver<$type>.toVarArg(): Pair<$type, $arrayType> =
+                    |@JvmName("toVararg$type")
+                    |fun $receiver<$type>.toVararg(): Pair<$type, $arrayType> =
                     |   first() to drop(1).to$arrayType()
                     |
                     """.trimMargin()
                 ).appendLine()
             }
-            toVarArg.append(
+            toVararg.append(
                 """
                 |/**
                 | * Splits this [Sequence] into the first element and the rest as [$arrayType].
@@ -370,8 +370,8 @@ val generate: TaskProvider<Task> = tasks.register("generate") {
                 | *
                 | * @since 3.1.0
                 | */
-                |@JvmName("toVarArg$type")
-                |fun Sequence<$type>.toVarArg(): Pair<$type, $arrayType> =
+                |@JvmName("toVararg$type")
+                |fun Sequence<$type>.toVararg(): Pair<$type, $arrayType> =
                 |   first() to drop(1).toList().to$arrayType()
                 |
                 |/**
@@ -381,8 +381,8 @@ val generate: TaskProvider<Task> = tasks.register("generate") {
                 | *
                 | * @since 3.1.0
                 | */
-                |@JvmName("toVarArg$type")
-                |fun $arrayType.toVarArg(): Pair<$type, $arrayType> =
+                |@JvmName("toVararg$type")
+                |fun $arrayType.toVararg(): Pair<$type, $arrayType> =
                 |   first() to drop(1).to$arrayType()
                 |
                 """.trimMargin()
@@ -412,8 +412,8 @@ val generate: TaskProvider<Task> = tasks.register("generate") {
         val tupleFlattenFile = packageDir.resolve("tupleFlatten.kt")
         tupleFlattenFile.writeText(tupleFlatten.toString())
 
-        val toVarArgFile = packageDir.resolve("toVarArg.kt")
-        toVarArgFile.writeText(toVarArg.toString())
+        val toVarargFile = packageDir.resolve("toVararg.kt")
+        toVarargFile.writeText(toVararg.toString())
     }
 }
 generationFolder.builtBy(generate)
@@ -453,9 +453,9 @@ val generateTest: TaskProvider<Task> = tasks.register("generateTest") {
         val tupleFactoryTest = createStringBuilder(packageName)
             .appendTest("TupleFactoryTest")
 
-        val toVarArgTest = createStringBuilder(packageName)
-            .appendTest("ToVarArgTest")
-        toVarArgTest.append(
+        val toVarargTest = createStringBuilder(packageName)
+            .appendTest("ToVarargTest")
+        toVarargTest.append(
             """
             |    fun expectString(s: String, vararg others: String) {}
             |    fun expectBoolean(first: Boolean, vararg others: Boolean) {}
@@ -468,9 +468,9 @@ val generateTest: TaskProvider<Task> = tasks.register("generateTest") {
             |    fun expectDouble(first: Double, vararg others: Double) {}
             |
             |    @Test
-            |    fun toVarArg_array() {
+            |    fun toVararg_array() {
             |        val arr = arrayOf("a", "b")
-            |        val pair = arr.toVarArg()
+            |        val pair = arr.toVararg()
             |
             |        val (first, rest) = pair
             |        expectString(first, *rest)
@@ -496,12 +496,12 @@ val generateTest: TaskProvider<Task> = tasks.register("generateTest") {
                 "Double" -> "1.0" to "2.0, 3.0"
                 else -> throw IllegalStateException("not all primitiveTypes cases covered: $type")
             }
-            toVarArgTest.append(
+            toVarargTest.append(
                 """
                 |    @Test
-                |    fun toVarArg_$arrayType() {
+                |    fun toVararg_$arrayType() {
                 |        val arr = ${arrayType}Of($value1, $value2)
-                |        val pair = arr.toVarArg()
+                |        val pair = arr.toVararg()
                 |
                 |        val (first, rest) = pair
                 |        expect$type(first, *rest)
@@ -514,12 +514,12 @@ val generateTest: TaskProvider<Task> = tasks.register("generateTest") {
                 """.trimMargin()
             ).appendLine().appendLine()
             listOf("Iterable" to "listOf", "Sequence" to "sequenceOf").forEach { (receiver, factory) ->
-                toVarArgTest.append(
+                toVarargTest.append(
                     """
                 |    @Test
-                |    fun toVarArg_${receiver}_of_${type}_returns_$arrayType() {
+                |    fun toVararg_${receiver}_of_${type}_returns_$arrayType() {
                 |        val arr: $receiver<$type> = ${factory}($value1, $value2)
-                |        val pair = arr.toVarArg()
+                |        val pair = arr.toVararg()
                 |
                 |        val (first, rest) = pair
                 |        expect$type(first, *rest)
@@ -826,9 +826,9 @@ val generateTest: TaskProvider<Task> = tasks.register("generateTest") {
         val factoryTestFile = packageDir.resolve("TupleFactoryTest.kt")
         factoryTestFile.writeText(tupleFactoryTest.toString())
 
-        toVarArgTest.append("}")
-        val toVarArgTestFile = packageDir.resolve("ToVarArgTest.kt")
-        toVarArgTestFile.writeText(toVarArgTest.toString())
+        toVarargTest.append("}")
+        val toVarargTestFile = packageDir.resolve("ToVarargTest.kt")
+        toVarargTestFile.writeText(toVarargTest.toString())
     }
 }
 generationTestFolder.builtBy(generateTest)

--- a/src/commonMain/generated/kotlin/ch/tutteli/kbox/toVararg.kt
+++ b/src/commonMain/generated/kotlin/ch/tutteli/kbox/toVararg.kt
@@ -11,7 +11,7 @@ import kotlin.jvm.JvmName/**
  *
  * @since 3.1.0
  */
-inline fun <reified T> Array<out T>.toVarArg(): Pair<T, Array<out T>> =
+inline fun <reified T> Array<out T>.toVararg(): Pair<T, Array<out T>> =
    first() to drop(1).toList().toTypedArray()
 
 /**
@@ -21,8 +21,8 @@ inline fun <reified T> Array<out T>.toVarArg(): Pair<T, Array<out T>> =
  *
  * @since 3.1.0
  */
-@JvmName("toVarArgBoolean")
-fun Iterable<Boolean>.toVarArg(): Pair<Boolean, BooleanArray> =
+@JvmName("toVarargBoolean")
+fun Iterable<Boolean>.toVararg(): Pair<Boolean, BooleanArray> =
    first() to drop(1).toBooleanArray()
 
 /**
@@ -32,8 +32,8 @@ fun Iterable<Boolean>.toVarArg(): Pair<Boolean, BooleanArray> =
  *
  * @since 3.1.0
  */
-@JvmName("toVarArgBoolean")
-fun Array<Boolean>.toVarArg(): Pair<Boolean, BooleanArray> =
+@JvmName("toVarargBoolean")
+fun Array<Boolean>.toVararg(): Pair<Boolean, BooleanArray> =
    first() to drop(1).toBooleanArray()
 
 /**
@@ -43,8 +43,8 @@ fun Array<Boolean>.toVarArg(): Pair<Boolean, BooleanArray> =
  *
  * @since 3.1.0
  */
-@JvmName("toVarArgBoolean")
-fun Sequence<Boolean>.toVarArg(): Pair<Boolean, BooleanArray> =
+@JvmName("toVarargBoolean")
+fun Sequence<Boolean>.toVararg(): Pair<Boolean, BooleanArray> =
    first() to drop(1).toList().toBooleanArray()
 
 /**
@@ -54,8 +54,8 @@ fun Sequence<Boolean>.toVarArg(): Pair<Boolean, BooleanArray> =
  *
  * @since 3.1.0
  */
-@JvmName("toVarArgBoolean")
-fun BooleanArray.toVarArg(): Pair<Boolean, BooleanArray> =
+@JvmName("toVarargBoolean")
+fun BooleanArray.toVararg(): Pair<Boolean, BooleanArray> =
    first() to drop(1).toBooleanArray()
 
 /**
@@ -65,8 +65,8 @@ fun BooleanArray.toVarArg(): Pair<Boolean, BooleanArray> =
  *
  * @since 3.1.0
  */
-@JvmName("toVarArgByte")
-fun Iterable<Byte>.toVarArg(): Pair<Byte, ByteArray> =
+@JvmName("toVarargByte")
+fun Iterable<Byte>.toVararg(): Pair<Byte, ByteArray> =
    first() to drop(1).toByteArray()
 
 /**
@@ -76,8 +76,8 @@ fun Iterable<Byte>.toVarArg(): Pair<Byte, ByteArray> =
  *
  * @since 3.1.0
  */
-@JvmName("toVarArgByte")
-fun Array<Byte>.toVarArg(): Pair<Byte, ByteArray> =
+@JvmName("toVarargByte")
+fun Array<Byte>.toVararg(): Pair<Byte, ByteArray> =
    first() to drop(1).toByteArray()
 
 /**
@@ -87,8 +87,8 @@ fun Array<Byte>.toVarArg(): Pair<Byte, ByteArray> =
  *
  * @since 3.1.0
  */
-@JvmName("toVarArgByte")
-fun Sequence<Byte>.toVarArg(): Pair<Byte, ByteArray> =
+@JvmName("toVarargByte")
+fun Sequence<Byte>.toVararg(): Pair<Byte, ByteArray> =
    first() to drop(1).toList().toByteArray()
 
 /**
@@ -98,8 +98,8 @@ fun Sequence<Byte>.toVarArg(): Pair<Byte, ByteArray> =
  *
  * @since 3.1.0
  */
-@JvmName("toVarArgByte")
-fun ByteArray.toVarArg(): Pair<Byte, ByteArray> =
+@JvmName("toVarargByte")
+fun ByteArray.toVararg(): Pair<Byte, ByteArray> =
    first() to drop(1).toByteArray()
 
 /**
@@ -109,8 +109,8 @@ fun ByteArray.toVarArg(): Pair<Byte, ByteArray> =
  *
  * @since 3.1.0
  */
-@JvmName("toVarArgChar")
-fun Iterable<Char>.toVarArg(): Pair<Char, CharArray> =
+@JvmName("toVarargChar")
+fun Iterable<Char>.toVararg(): Pair<Char, CharArray> =
    first() to drop(1).toCharArray()
 
 /**
@@ -120,8 +120,8 @@ fun Iterable<Char>.toVarArg(): Pair<Char, CharArray> =
  *
  * @since 3.1.0
  */
-@JvmName("toVarArgChar")
-fun Array<Char>.toVarArg(): Pair<Char, CharArray> =
+@JvmName("toVarargChar")
+fun Array<Char>.toVararg(): Pair<Char, CharArray> =
    first() to drop(1).toCharArray()
 
 /**
@@ -131,8 +131,8 @@ fun Array<Char>.toVarArg(): Pair<Char, CharArray> =
  *
  * @since 3.1.0
  */
-@JvmName("toVarArgChar")
-fun Sequence<Char>.toVarArg(): Pair<Char, CharArray> =
+@JvmName("toVarargChar")
+fun Sequence<Char>.toVararg(): Pair<Char, CharArray> =
    first() to drop(1).toList().toCharArray()
 
 /**
@@ -142,8 +142,8 @@ fun Sequence<Char>.toVarArg(): Pair<Char, CharArray> =
  *
  * @since 3.1.0
  */
-@JvmName("toVarArgChar")
-fun CharArray.toVarArg(): Pair<Char, CharArray> =
+@JvmName("toVarargChar")
+fun CharArray.toVararg(): Pair<Char, CharArray> =
    first() to drop(1).toCharArray()
 
 /**
@@ -153,8 +153,8 @@ fun CharArray.toVarArg(): Pair<Char, CharArray> =
  *
  * @since 3.1.0
  */
-@JvmName("toVarArgShort")
-fun Iterable<Short>.toVarArg(): Pair<Short, ShortArray> =
+@JvmName("toVarargShort")
+fun Iterable<Short>.toVararg(): Pair<Short, ShortArray> =
    first() to drop(1).toShortArray()
 
 /**
@@ -164,8 +164,8 @@ fun Iterable<Short>.toVarArg(): Pair<Short, ShortArray> =
  *
  * @since 3.1.0
  */
-@JvmName("toVarArgShort")
-fun Array<Short>.toVarArg(): Pair<Short, ShortArray> =
+@JvmName("toVarargShort")
+fun Array<Short>.toVararg(): Pair<Short, ShortArray> =
    first() to drop(1).toShortArray()
 
 /**
@@ -175,8 +175,8 @@ fun Array<Short>.toVarArg(): Pair<Short, ShortArray> =
  *
  * @since 3.1.0
  */
-@JvmName("toVarArgShort")
-fun Sequence<Short>.toVarArg(): Pair<Short, ShortArray> =
+@JvmName("toVarargShort")
+fun Sequence<Short>.toVararg(): Pair<Short, ShortArray> =
    first() to drop(1).toList().toShortArray()
 
 /**
@@ -186,8 +186,8 @@ fun Sequence<Short>.toVarArg(): Pair<Short, ShortArray> =
  *
  * @since 3.1.0
  */
-@JvmName("toVarArgShort")
-fun ShortArray.toVarArg(): Pair<Short, ShortArray> =
+@JvmName("toVarargShort")
+fun ShortArray.toVararg(): Pair<Short, ShortArray> =
    first() to drop(1).toShortArray()
 
 /**
@@ -197,8 +197,8 @@ fun ShortArray.toVarArg(): Pair<Short, ShortArray> =
  *
  * @since 3.1.0
  */
-@JvmName("toVarArgInt")
-fun Iterable<Int>.toVarArg(): Pair<Int, IntArray> =
+@JvmName("toVarargInt")
+fun Iterable<Int>.toVararg(): Pair<Int, IntArray> =
    first() to drop(1).toIntArray()
 
 /**
@@ -208,8 +208,8 @@ fun Iterable<Int>.toVarArg(): Pair<Int, IntArray> =
  *
  * @since 3.1.0
  */
-@JvmName("toVarArgInt")
-fun Array<Int>.toVarArg(): Pair<Int, IntArray> =
+@JvmName("toVarargInt")
+fun Array<Int>.toVararg(): Pair<Int, IntArray> =
    first() to drop(1).toIntArray()
 
 /**
@@ -219,8 +219,8 @@ fun Array<Int>.toVarArg(): Pair<Int, IntArray> =
  *
  * @since 3.1.0
  */
-@JvmName("toVarArgInt")
-fun Sequence<Int>.toVarArg(): Pair<Int, IntArray> =
+@JvmName("toVarargInt")
+fun Sequence<Int>.toVararg(): Pair<Int, IntArray> =
    first() to drop(1).toList().toIntArray()
 
 /**
@@ -230,8 +230,8 @@ fun Sequence<Int>.toVarArg(): Pair<Int, IntArray> =
  *
  * @since 3.1.0
  */
-@JvmName("toVarArgInt")
-fun IntArray.toVarArg(): Pair<Int, IntArray> =
+@JvmName("toVarargInt")
+fun IntArray.toVararg(): Pair<Int, IntArray> =
    first() to drop(1).toIntArray()
 
 /**
@@ -241,8 +241,8 @@ fun IntArray.toVarArg(): Pair<Int, IntArray> =
  *
  * @since 3.1.0
  */
-@JvmName("toVarArgLong")
-fun Iterable<Long>.toVarArg(): Pair<Long, LongArray> =
+@JvmName("toVarargLong")
+fun Iterable<Long>.toVararg(): Pair<Long, LongArray> =
    first() to drop(1).toLongArray()
 
 /**
@@ -252,8 +252,8 @@ fun Iterable<Long>.toVarArg(): Pair<Long, LongArray> =
  *
  * @since 3.1.0
  */
-@JvmName("toVarArgLong")
-fun Array<Long>.toVarArg(): Pair<Long, LongArray> =
+@JvmName("toVarargLong")
+fun Array<Long>.toVararg(): Pair<Long, LongArray> =
    first() to drop(1).toLongArray()
 
 /**
@@ -263,8 +263,8 @@ fun Array<Long>.toVarArg(): Pair<Long, LongArray> =
  *
  * @since 3.1.0
  */
-@JvmName("toVarArgLong")
-fun Sequence<Long>.toVarArg(): Pair<Long, LongArray> =
+@JvmName("toVarargLong")
+fun Sequence<Long>.toVararg(): Pair<Long, LongArray> =
    first() to drop(1).toList().toLongArray()
 
 /**
@@ -274,8 +274,8 @@ fun Sequence<Long>.toVarArg(): Pair<Long, LongArray> =
  *
  * @since 3.1.0
  */
-@JvmName("toVarArgLong")
-fun LongArray.toVarArg(): Pair<Long, LongArray> =
+@JvmName("toVarargLong")
+fun LongArray.toVararg(): Pair<Long, LongArray> =
    first() to drop(1).toLongArray()
 
 /**
@@ -285,8 +285,8 @@ fun LongArray.toVarArg(): Pair<Long, LongArray> =
  *
  * @since 3.1.0
  */
-@JvmName("toVarArgFloat")
-fun Iterable<Float>.toVarArg(): Pair<Float, FloatArray> =
+@JvmName("toVarargFloat")
+fun Iterable<Float>.toVararg(): Pair<Float, FloatArray> =
    first() to drop(1).toFloatArray()
 
 /**
@@ -296,8 +296,8 @@ fun Iterable<Float>.toVarArg(): Pair<Float, FloatArray> =
  *
  * @since 3.1.0
  */
-@JvmName("toVarArgFloat")
-fun Array<Float>.toVarArg(): Pair<Float, FloatArray> =
+@JvmName("toVarargFloat")
+fun Array<Float>.toVararg(): Pair<Float, FloatArray> =
    first() to drop(1).toFloatArray()
 
 /**
@@ -307,8 +307,8 @@ fun Array<Float>.toVarArg(): Pair<Float, FloatArray> =
  *
  * @since 3.1.0
  */
-@JvmName("toVarArgFloat")
-fun Sequence<Float>.toVarArg(): Pair<Float, FloatArray> =
+@JvmName("toVarargFloat")
+fun Sequence<Float>.toVararg(): Pair<Float, FloatArray> =
    first() to drop(1).toList().toFloatArray()
 
 /**
@@ -318,8 +318,8 @@ fun Sequence<Float>.toVarArg(): Pair<Float, FloatArray> =
  *
  * @since 3.1.0
  */
-@JvmName("toVarArgFloat")
-fun FloatArray.toVarArg(): Pair<Float, FloatArray> =
+@JvmName("toVarargFloat")
+fun FloatArray.toVararg(): Pair<Float, FloatArray> =
    first() to drop(1).toFloatArray()
 
 /**
@@ -329,8 +329,8 @@ fun FloatArray.toVarArg(): Pair<Float, FloatArray> =
  *
  * @since 3.1.0
  */
-@JvmName("toVarArgDouble")
-fun Iterable<Double>.toVarArg(): Pair<Double, DoubleArray> =
+@JvmName("toVarargDouble")
+fun Iterable<Double>.toVararg(): Pair<Double, DoubleArray> =
    first() to drop(1).toDoubleArray()
 
 /**
@@ -340,8 +340,8 @@ fun Iterable<Double>.toVarArg(): Pair<Double, DoubleArray> =
  *
  * @since 3.1.0
  */
-@JvmName("toVarArgDouble")
-fun Array<Double>.toVarArg(): Pair<Double, DoubleArray> =
+@JvmName("toVarargDouble")
+fun Array<Double>.toVararg(): Pair<Double, DoubleArray> =
    first() to drop(1).toDoubleArray()
 
 /**
@@ -351,8 +351,8 @@ fun Array<Double>.toVarArg(): Pair<Double, DoubleArray> =
  *
  * @since 3.1.0
  */
-@JvmName("toVarArgDouble")
-fun Sequence<Double>.toVarArg(): Pair<Double, DoubleArray> =
+@JvmName("toVarargDouble")
+fun Sequence<Double>.toVararg(): Pair<Double, DoubleArray> =
    first() to drop(1).toList().toDoubleArray()
 
 /**
@@ -362,7 +362,7 @@ fun Sequence<Double>.toVarArg(): Pair<Double, DoubleArray> =
  *
  * @since 3.1.0
  */
-@JvmName("toVarArgDouble")
-fun DoubleArray.toVarArg(): Pair<Double, DoubleArray> =
+@JvmName("toVarargDouble")
+fun DoubleArray.toVararg(): Pair<Double, DoubleArray> =
    first() to drop(1).toDoubleArray()
 

--- a/src/commonTest/generated/kotlin/ch/tutteli/kbox/ToVarargTest.kt
+++ b/src/commonTest/generated/kotlin/ch/tutteli/kbox/ToVarargTest.kt
@@ -9,7 +9,7 @@ import ch.tutteli.atrium.api.verbs.expect
 import ch.tutteli.kbox.*
 import kotlin.test.Test
 
-class ToVarArgTest {
+class ToVarargTest {
 
     fun expectString(s: String, vararg others: String) {}
     fun expectBoolean(first: Boolean, vararg others: Boolean) {}
@@ -22,9 +22,9 @@ class ToVarArgTest {
     fun expectDouble(first: Double, vararg others: Double) {}
 
     @Test
-    fun toVarArg_array() {
+    fun toVararg_array() {
         val arr = arrayOf("a", "b")
-        val pair = arr.toVarArg()
+        val pair = arr.toVararg()
 
         val (first, rest) = pair
         expectString(first, *rest)
@@ -36,9 +36,9 @@ class ToVarArgTest {
     }
 
     @Test
-    fun toVarArg_booleanArray() {
+    fun toVararg_booleanArray() {
         val arr = booleanArrayOf(false, true)
-        val pair = arr.toVarArg()
+        val pair = arr.toVararg()
 
         val (first, rest) = pair
         expectBoolean(first, *rest)
@@ -50,9 +50,9 @@ class ToVarArgTest {
     }
 
     @Test
-    fun toVarArg_Iterable_of_Boolean_returns_booleanArray() {
+    fun toVararg_Iterable_of_Boolean_returns_booleanArray() {
         val arr: Iterable<Boolean> = listOf(false, true)
-        val pair = arr.toVarArg()
+        val pair = arr.toVararg()
 
         val (first, rest) = pair
         expectBoolean(first, *rest)
@@ -64,9 +64,9 @@ class ToVarArgTest {
     }
 
     @Test
-    fun toVarArg_Sequence_of_Boolean_returns_booleanArray() {
+    fun toVararg_Sequence_of_Boolean_returns_booleanArray() {
         val arr: Sequence<Boolean> = sequenceOf(false, true)
-        val pair = arr.toVarArg()
+        val pair = arr.toVararg()
 
         val (first, rest) = pair
         expectBoolean(first, *rest)
@@ -78,9 +78,9 @@ class ToVarArgTest {
     }
 
     @Test
-    fun toVarArg_byteArray() {
+    fun toVararg_byteArray() {
         val arr = byteArrayOf(1.toByte(), 2.toByte())
-        val pair = arr.toVarArg()
+        val pair = arr.toVararg()
 
         val (first, rest) = pair
         expectByte(first, *rest)
@@ -92,9 +92,9 @@ class ToVarArgTest {
     }
 
     @Test
-    fun toVarArg_Iterable_of_Byte_returns_byteArray() {
+    fun toVararg_Iterable_of_Byte_returns_byteArray() {
         val arr: Iterable<Byte> = listOf(1.toByte(), 2.toByte())
-        val pair = arr.toVarArg()
+        val pair = arr.toVararg()
 
         val (first, rest) = pair
         expectByte(first, *rest)
@@ -106,9 +106,9 @@ class ToVarArgTest {
     }
 
     @Test
-    fun toVarArg_Sequence_of_Byte_returns_byteArray() {
+    fun toVararg_Sequence_of_Byte_returns_byteArray() {
         val arr: Sequence<Byte> = sequenceOf(1.toByte(), 2.toByte())
-        val pair = arr.toVarArg()
+        val pair = arr.toVararg()
 
         val (first, rest) = pair
         expectByte(first, *rest)
@@ -120,9 +120,9 @@ class ToVarArgTest {
     }
 
     @Test
-    fun toVarArg_charArray() {
+    fun toVararg_charArray() {
         val arr = charArrayOf('a', 'b', 'c', 'd')
-        val pair = arr.toVarArg()
+        val pair = arr.toVararg()
 
         val (first, rest) = pair
         expectChar(first, *rest)
@@ -134,9 +134,9 @@ class ToVarArgTest {
     }
 
     @Test
-    fun toVarArg_Iterable_of_Char_returns_charArray() {
+    fun toVararg_Iterable_of_Char_returns_charArray() {
         val arr: Iterable<Char> = listOf('a', 'b', 'c', 'd')
-        val pair = arr.toVarArg()
+        val pair = arr.toVararg()
 
         val (first, rest) = pair
         expectChar(first, *rest)
@@ -148,9 +148,9 @@ class ToVarArgTest {
     }
 
     @Test
-    fun toVarArg_Sequence_of_Char_returns_charArray() {
+    fun toVararg_Sequence_of_Char_returns_charArray() {
         val arr: Sequence<Char> = sequenceOf('a', 'b', 'c', 'd')
-        val pair = arr.toVarArg()
+        val pair = arr.toVararg()
 
         val (first, rest) = pair
         expectChar(first, *rest)
@@ -162,9 +162,9 @@ class ToVarArgTest {
     }
 
     @Test
-    fun toVarArg_shortArray() {
+    fun toVararg_shortArray() {
         val arr = shortArrayOf(1.toShort(), 2.toShort())
-        val pair = arr.toVarArg()
+        val pair = arr.toVararg()
 
         val (first, rest) = pair
         expectShort(first, *rest)
@@ -176,9 +176,9 @@ class ToVarArgTest {
     }
 
     @Test
-    fun toVarArg_Iterable_of_Short_returns_shortArray() {
+    fun toVararg_Iterable_of_Short_returns_shortArray() {
         val arr: Iterable<Short> = listOf(1.toShort(), 2.toShort())
-        val pair = arr.toVarArg()
+        val pair = arr.toVararg()
 
         val (first, rest) = pair
         expectShort(first, *rest)
@@ -190,9 +190,9 @@ class ToVarArgTest {
     }
 
     @Test
-    fun toVarArg_Sequence_of_Short_returns_shortArray() {
+    fun toVararg_Sequence_of_Short_returns_shortArray() {
         val arr: Sequence<Short> = sequenceOf(1.toShort(), 2.toShort())
-        val pair = arr.toVarArg()
+        val pair = arr.toVararg()
 
         val (first, rest) = pair
         expectShort(first, *rest)
@@ -204,9 +204,9 @@ class ToVarArgTest {
     }
 
     @Test
-    fun toVarArg_intArray() {
+    fun toVararg_intArray() {
         val arr = intArrayOf(1, 2, 3, 4, 5, 6, 7)
-        val pair = arr.toVarArg()
+        val pair = arr.toVararg()
 
         val (first, rest) = pair
         expectInt(first, *rest)
@@ -218,9 +218,9 @@ class ToVarArgTest {
     }
 
     @Test
-    fun toVarArg_Iterable_of_Int_returns_intArray() {
+    fun toVararg_Iterable_of_Int_returns_intArray() {
         val arr: Iterable<Int> = listOf(1, 2, 3, 4, 5, 6, 7)
-        val pair = arr.toVarArg()
+        val pair = arr.toVararg()
 
         val (first, rest) = pair
         expectInt(first, *rest)
@@ -232,9 +232,9 @@ class ToVarArgTest {
     }
 
     @Test
-    fun toVarArg_Sequence_of_Int_returns_intArray() {
+    fun toVararg_Sequence_of_Int_returns_intArray() {
         val arr: Sequence<Int> = sequenceOf(1, 2, 3, 4, 5, 6, 7)
-        val pair = arr.toVarArg()
+        val pair = arr.toVararg()
 
         val (first, rest) = pair
         expectInt(first, *rest)
@@ -246,9 +246,9 @@ class ToVarArgTest {
     }
 
     @Test
-    fun toVarArg_longArray() {
+    fun toVararg_longArray() {
         val arr = longArrayOf(1L, 2L)
-        val pair = arr.toVarArg()
+        val pair = arr.toVararg()
 
         val (first, rest) = pair
         expectLong(first, *rest)
@@ -260,9 +260,9 @@ class ToVarArgTest {
     }
 
     @Test
-    fun toVarArg_Iterable_of_Long_returns_longArray() {
+    fun toVararg_Iterable_of_Long_returns_longArray() {
         val arr: Iterable<Long> = listOf(1L, 2L)
-        val pair = arr.toVarArg()
+        val pair = arr.toVararg()
 
         val (first, rest) = pair
         expectLong(first, *rest)
@@ -274,9 +274,9 @@ class ToVarArgTest {
     }
 
     @Test
-    fun toVarArg_Sequence_of_Long_returns_longArray() {
+    fun toVararg_Sequence_of_Long_returns_longArray() {
         val arr: Sequence<Long> = sequenceOf(1L, 2L)
-        val pair = arr.toVarArg()
+        val pair = arr.toVararg()
 
         val (first, rest) = pair
         expectLong(first, *rest)
@@ -288,9 +288,9 @@ class ToVarArgTest {
     }
 
     @Test
-    fun toVarArg_floatArray() {
+    fun toVararg_floatArray() {
         val arr = floatArrayOf(1.0f, 2.0f)
-        val pair = arr.toVarArg()
+        val pair = arr.toVararg()
 
         val (first, rest) = pair
         expectFloat(first, *rest)
@@ -302,9 +302,9 @@ class ToVarArgTest {
     }
 
     @Test
-    fun toVarArg_Iterable_of_Float_returns_floatArray() {
+    fun toVararg_Iterable_of_Float_returns_floatArray() {
         val arr: Iterable<Float> = listOf(1.0f, 2.0f)
-        val pair = arr.toVarArg()
+        val pair = arr.toVararg()
 
         val (first, rest) = pair
         expectFloat(first, *rest)
@@ -316,9 +316,9 @@ class ToVarArgTest {
     }
 
     @Test
-    fun toVarArg_Sequence_of_Float_returns_floatArray() {
+    fun toVararg_Sequence_of_Float_returns_floatArray() {
         val arr: Sequence<Float> = sequenceOf(1.0f, 2.0f)
-        val pair = arr.toVarArg()
+        val pair = arr.toVararg()
 
         val (first, rest) = pair
         expectFloat(first, *rest)
@@ -330,9 +330,9 @@ class ToVarArgTest {
     }
 
     @Test
-    fun toVarArg_doubleArray() {
+    fun toVararg_doubleArray() {
         val arr = doubleArrayOf(1.0, 2.0, 3.0)
-        val pair = arr.toVarArg()
+        val pair = arr.toVararg()
 
         val (first, rest) = pair
         expectDouble(first, *rest)
@@ -344,9 +344,9 @@ class ToVarArgTest {
     }
 
     @Test
-    fun toVarArg_Iterable_of_Double_returns_doubleArray() {
+    fun toVararg_Iterable_of_Double_returns_doubleArray() {
         val arr: Iterable<Double> = listOf(1.0, 2.0, 3.0)
-        val pair = arr.toVarArg()
+        val pair = arr.toVararg()
 
         val (first, rest) = pair
         expectDouble(first, *rest)
@@ -358,9 +358,9 @@ class ToVarArgTest {
     }
 
     @Test
-    fun toVarArg_Sequence_of_Double_returns_doubleArray() {
+    fun toVararg_Sequence_of_Double_returns_doubleArray() {
         val arr: Sequence<Double> = sequenceOf(1.0, 2.0, 3.0)
-        val pair = arr.toVarArg()
+        val pair = arr.toVararg()
 
         val (first, rest) = pair
         expectDouble(first, *rest)


### PR DESCRIPTION
and in order to be in line with the keyword `vararg`